### PR TITLE
Full pawn tactic and minor fixes

### DIFF
--- a/ui/00_message/skill/ability_info.xml
+++ b/ui/00_message/skill/ability_info.xml
@@ -900,7 +900,7 @@ beast-type enemies.
     <original>錬金系の敵から受けるダメージ量が減少する
 &lt;COL ffdc78&gt;LV UP毎にダメージさらに軽減&lt;/COL&gt;</original>
     <translation>Decrease damage received from
-alchemy-enhanced enemies.
+alchemised enemies.
 &lt;COL ffdc78&gt;LV UP: Decreases damage further.&lt;/COL&gt;</translation>
   </message>
   <message>
@@ -1175,7 +1175,7 @@ beast-type enemies.
     <original>錬金系の敵に与えるダメージ量が増加する
 &lt;COL ffdc78&gt;LV UP毎にダメージがより増加&lt;/COL&gt;</original>
     <translation>Increases the damage you deal towards
-alchemy-enhanced enemies.
+alchemised enemies.
 &lt;COL ffdc78&gt;LV UP: Further increases damage.&lt;/COL&gt;</translation>
   </message>
   <message>

--- a/ui/00_message/skill/ability_info.xml
+++ b/ui/00_message/skill/ability_info.xml
@@ -3763,7 +3763,7 @@ safely fall.
     <key>ABILITY_INFO_461</key>
     <original>友体/友活/友攻/友魔/友防/友護の
 Lv6以上の全てのアビリティ効果が付与される</original>
-    <translation>Grant the effect above Lv6 of the following augments:
+    <translation>Grant the effect beyond Lv6 of the following augments:
 Companion Health, Companion Stamina, Companion Attack,
 Companion Magick, Companion Defense, Companion Magick Defense.</translation>
   </message>
@@ -3771,7 +3771,7 @@ Companion Magick, Companion Defense, Companion Magick Defense.</translation>
     <key>ABILITY_INFO_462</key>
     <original>探採/宝眼/延泉/安着/流断/薬効の
 Lv6以上の全てのアビリティ効果が付与される</original>
-    <translation>Grant the effect above Lv6 of the following augments:
+    <translation>Grant the effect beyond Lv6 of the following augments:
 Gathering, Treasure Eye, Extended Springs,
 Safe Landing, Flow, Efficacy.
     </translation>
@@ -3780,7 +3780,7 @@ Safe Landing, Flow, Efficacy.
     <key>ABILITY_INFO_463</key>
     <original>侵壊/侵護/減侵/豪握/強壮の
 Lv6以上の全てのアビリティ効果が付与される</original>
-    <translation>Grant the effect above Lv6 of the following augments:
+    <translation>Grant the effect beyond Lv6 of the following augments:
 Infected Destroyer, Infected Safeguard,
 Reduced Corruption, Great Grasp, Hardy.
     </translation>
@@ -3789,7 +3789,7 @@ Reduced Corruption, Great Grasp, Hardy.
     <key>ABILITY_INFO_464</key>
     <original>羅刹/夜叉/空滅/速離/聖体の
 Lv6以上の全てのアビリティ効果が付与される</original>
-    <translation>Grant the effect above Lv6 of the following augments:
+    <translation>Grant the effect beyond Lv6 of the following augments:
 Rakshasa, Yasha, Sky Annihilation,
 Egression, Holy Body.
     </translation>

--- a/ui/00_message/skill/ability_info.xml
+++ b/ui/00_message/skill/ability_info.xml
@@ -884,7 +884,7 @@ Demon enemies.
     <original>造魔系の敵に与えるダメージ量が増加する
 &lt;COL ffdc78&gt;LV UP毎にダメージがより増加&lt;/COL&gt;</original>
     <translation>Increases the damage you deal towards
-construct-type enemies.
+magickal constructed enemies.
 &lt;COL ffdc78&gt;LV UP: Further increases damage.&lt;/COL&gt;</translation>
   </message>
   <message>
@@ -1159,7 +1159,7 @@ making it easier to increase the magic's power.
     <original>造魔系の敵から受けるダメージ量が減少する
 &lt;COL ffdc78&gt;LV UP毎にダメージさらに軽減&lt;/COL&gt;</original>
     <translation>Decrease damage received from
-construct-type enemies.
+magickal constructed enemies.
 &lt;COL ffdc78&gt;LV UP: Decreases damage further.&lt;/COL&gt;</translation>
   </message>
   <message>

--- a/ui/00_message/skill/ability_info.xml
+++ b/ui/00_message/skill/ability_info.xml
@@ -900,7 +900,7 @@ beast-type enemies.
     <original>錬金系の敵から受けるダメージ量が減少する
 &lt;COL ffdc78&gt;LV UP毎にダメージさらに軽減&lt;/COL&gt;</original>
     <translation>Decrease damage received from
-alchemised enemies.
+alchemized enemies.
 &lt;COL ffdc78&gt;LV UP: Decreases damage further.&lt;/COL&gt;</translation>
   </message>
   <message>
@@ -1175,7 +1175,7 @@ beast-type enemies.
     <original>錬金系の敵に与えるダメージ量が増加する
 &lt;COL ffdc78&gt;LV UP毎にダメージがより増加&lt;/COL&gt;</original>
     <translation>Increases the damage you deal towards
-alchemised enemies.
+alchemized enemies.
 &lt;COL ffdc78&gt;LV UP: Further increases damage.&lt;/COL&gt;</translation>
   </message>
   <message>

--- a/ui/00_message/skill/ability_info.xml
+++ b/ui/00_message/skill/ability_info.xml
@@ -584,9 +584,9 @@ after picking them up from incapacitation.
     <original>白竜神殿から出てしばらくの間
 最大体力が増加する
 &lt;COL ffdc78&gt;LV UP毎に最大体力がより増加&lt;/COL&gt;</original>
-    <translation>Increases your Strength after leaving
+    <translation>Increases your health after leaving
 White Dragon Temple for a period of time.
-&lt;COL ffdc78&gt;LV UP: Increases Strength further.&lt;/COL&gt;</translation>
+&lt;COL ffdc78&gt;LV UP: Increases health further.&lt;/COL&gt;</translation>
   </message>
   <message>
     <key>ABILITY_INFO_106</key>
@@ -723,7 +723,7 @@ and you do not stagger from enemy attacks.
     <original>エリクシル発動の予備動作が短縮される
 &lt;COL ffdc78&gt;LV UP毎に予備動作さらに短縮&lt;/COL&gt;</original>
     <translation>Decreases the time required to prepare your
-elixer.
+Elixir.
 &lt;COL ffdc78&gt;LV UP: Further decreases preparation time.&lt;/COL&gt;</translation>
   </message>
   <message>
@@ -1265,7 +1265,7 @@ attacks.
     <original>エリクシル発動時、変換する状態異常値が上昇する
 &lt;COL ffdc78&gt;LV UP毎に状態異常値がより増加&lt;/COL&gt;</original>
     <translation>Increases the effectiveness of your chosen status
-when activating Elixer.
+when activating Elixir.
 &lt;COL ffdc78&gt;LV UP: Further increases status effectiveness.&lt;/COL&gt;</translation>
   </message>
   <message>
@@ -2146,7 +2146,7 @@ attacks.
 スタミナが回復する
 &lt;COL ffdc78&gt;LV UP毎にスタミナ回復量がより増加&lt;/COL&gt;</original>
     <translation>Recovers your stamina when using a fully
-alchemized Elixer.
+alchemized Elixir.
 &lt;COL ffdc78&gt;LV UP: Further increases stamina recovered.&lt;/COL&gt;</translation>
   </message>
   <message>
@@ -2528,7 +2528,7 @@ LV5~6: Increases stun power.&lt;/COL&gt;</translation>
     <original>エリクシルのダメージ量が増加する
 &lt;COL ffdc78&gt;LV UP毎にダメージがより増加
 LV5～6で吹き飛ばし力が増加&lt;/COL&gt;</original>
-    <translation>Increases the damage of Elixer.
+    <translation>Increases the damage of Elixir.
 &lt;COL ffdc78&gt;LV UP: Further increases damage.
 LV5~6: Increases stagger power.&lt;/COL&gt;</translation>
   </message>
@@ -3763,20 +3763,35 @@ safely fall.
     <key>ABILITY_INFO_461</key>
     <original>友体/友活/友攻/友魔/友防/友護の
 Lv6以上の全てのアビリティ効果が付与される</original>
+    <translation>Grant the effect above Lv6 of the following augments:
+Companion Health, Companion Stamina, Companion Attack,
+Companion Magick, Companion Defense, Companion Magick Defense.</translation>
   </message>
   <message>
     <key>ABILITY_INFO_462</key>
     <original>探採/宝眼/延泉/安着/流断/薬効の
 Lv6以上の全てのアビリティ効果が付与される</original>
+    <translation>Grant the effect above Lv6 of the following augments:
+Gathering, Treasure Eye, Extended Springs,
+Safe Landing, Flow, Efficacy.
+    </translation>
   </message>
   <message>
     <key>ABILITY_INFO_463</key>
     <original>侵壊/侵護/減侵/豪握/強壮の
 Lv6以上の全てのアビリティ効果が付与される</original>
+    <translation>Grant the effect above Lv6 of the following augments:
+Infected Destroyer, Infected Safeguard,
+Reduced Corruption, Great Grasp, Hardy.
+    </translation>
   </message>
   <message>
     <key>ABILITY_INFO_464</key>
     <original>羅刹/夜叉/空滅/速離/聖体の
 Lv6以上の全てのアビリティ効果が付与される</original>
+    <translation>Grant the effect above Lv6 of the following augments:
+Rakshasa, Yasha, Sky Annihilation,
+Egression, Holy Body.
+    </translation>
   </message>
 </resource>

--- a/ui/00_message/skill/ability_name.xml
+++ b/ui/00_message/skill/ability_name.xml
@@ -522,7 +522,7 @@
   <message>
     <key>ABILITY_NAME_175</key>
     <original>造狙</original>
-    <translation>Rock Proficiency</translation>
+    <translation>Construct Proficiency</translation>
   </message>
   <message>
     <key>ABILITY_NAME_200</key>
@@ -687,7 +687,7 @@
   <message>
     <key>ABILITY_NAME_174</key>
     <original>造護</original>
-    <translation>Rock Safeguard</translation>
+    <translation>Construct Safeguard</translation>
   </message>
   <message>
     <key>ABILITY_NAME_199</key>

--- a/ui/00_message/skill/custom_skill_info_01.xml
+++ b/ui/00_message/skill/custom_skill_info_01.xml
@@ -189,7 +189,7 @@ slash.&lt;/COL&gt;</translation>
 Increase damage.
 Increase number of hits.
 Slightly increase chance attack and Fatigue attack.
-&lt;COL ff7878&gt;Further increase damage to Human/Dragon/Alchemy type enemies.&lt;/COL&gt;</translation>
+&lt;COL ff7878&gt;Further increase damage to Human/Dragonkin/Alchemised type enemies.&lt;/COL&gt;</translation>
   </message>
   <message>
     <key>CUSTOM_SKILL_INFO_01_155</key>

--- a/ui/00_message/skill/custom_skill_info_01.xml
+++ b/ui/00_message/skill/custom_skill_info_01.xml
@@ -189,7 +189,7 @@ slash.&lt;/COL&gt;</translation>
 Increase damage.
 Increase number of hits.
 Slightly increase chance attack and Fatigue attack.
-&lt;COL ff7878&gt;Further increase damage to Human/Dragonkin/Alchemised type enemies.&lt;/COL&gt;</translation>
+&lt;COL ff7878&gt;Further increase damage to Human/Dragonkin/Alchemized type enemies.&lt;/COL&gt;</translation>
   </message>
   <message>
     <key>CUSTOM_SKILL_INFO_01_155</key>

--- a/ui/00_message/skill/custom_skill_info_04.xml
+++ b/ui/00_message/skill/custom_skill_info_04.xml
@@ -194,7 +194,7 @@ Duration of effect after Field Shift is greatly increased.</translation>
 Increase the number of magick spheres (5→7)
 Increase damage and blow force.
 Increase chance attack and exhaust attack.
-&lt;COL ff7878&gt;Further increase damage against Skeleton/Infected/Cursed/Spirit enemies.&lt;/COL&gt;</translation>
+&lt;COL ff7878&gt;Further increase damage against Skeleton/Undead/Cursed/Spirit enemies.&lt;/COL&gt;</translation>
   </message>
   <message>
     <key>CUSTOM_SKILL_INFO_04_169</key>

--- a/ui/00_message/skill/custom_skill_info_09.xml
+++ b/ui/00_message/skill/custom_skill_info_09.xml
@@ -188,7 +188,7 @@ stake struck by this skill using Elixir/Alchemical Burst.</translation>
     <translation>EX Additional Effects:
 Increase damage.
 Add Gilded status abnormality.
-&lt;COL ff7878&gt;Further increase damage against Human/Dragon/Alchemy enemies.&lt;/COL&gt;
+&lt;COL ff7878&gt;Further increase damage against Human/Dragonkin/Alchemised enemies.&lt;/COL&gt;
 </translation>
   </message>
   <message>

--- a/ui/00_message/skill/custom_skill_info_09.xml
+++ b/ui/00_message/skill/custom_skill_info_09.xml
@@ -199,7 +199,7 @@ Add Gilded status abnormality.
 敵に与える錬成値と吹き飛ばし力が増加
 のけぞり、吹き飛び中でも発動可能</original>
     <translation>EX Additional Effects:
-Increase physic and magick defense during execution.
+Increase physical and magick defense during execution.
 Increase endurance during execution.
 Increase the amount of alchemical substance and blow force.
 Possible to use when being knocked back.</translation>

--- a/ui/00_message/skill/custom_skill_info_09.xml
+++ b/ui/00_message/skill/custom_skill_info_09.xml
@@ -188,7 +188,7 @@ stake struck by this skill using Elixir/Alchemical Burst.</translation>
     <translation>EX Additional Effects:
 Increase damage.
 Add Gilded status abnormality.
-&lt;COL ff7878&gt;Further increase damage against Human/Dragonkin/Alchemised enemies.&lt;/COL&gt;
+&lt;COL ff7878&gt;Further increase damage against Human/Dragonkin/Alchemized enemies.&lt;/COL&gt;
 </translation>
   </message>
   <message>

--- a/ui/00_message/skill/custom_skill_info_10.xml
+++ b/ui/00_message/skill/custom_skill_info_10.xml
@@ -145,7 +145,7 @@ Extend the duration of the pool.</translation>
 &lt;COL ff7878&gt;造魔／魔族／戦甲系の敵に与えるダメージ量が増加&lt;/COL&gt;</original>
     <translation>EX Additional Effects:
 Increase damage.
-&lt;COL ff7878&gt;Further increase damage to Demon/Ogre/War-Ready enemies.&lt;/COL&gt;</translation>
+&lt;COL ff7878&gt;Further increase damage to Rock/Ogre/War-Ready enemies.&lt;/COL&gt;</translation>
   </message>
   <message>
     <key>CUSTOM_SKILL_INFO_10_194</key>

--- a/ui/00_message/skill/custom_skill_info_10.xml
+++ b/ui/00_message/skill/custom_skill_info_10.xml
@@ -145,7 +145,7 @@ Extend the duration of the pool.</translation>
 &lt;COL ff7878&gt;造魔／魔族／戦甲系の敵に与えるダメージ量が増加&lt;/COL&gt;</original>
     <translation>EX Additional Effects:
 Increase damage.
-&lt;COL ff7878&gt;Further increase damage to Rock/Ogre/War-Ready enemies.&lt;/COL&gt;</translation>
+&lt;COL ff7878&gt;Further increase damage to Construct/Demon/War-Ready enemies.&lt;/COL&gt;</translation>
   </message>
   <message>
     <key>CUSTOM_SKILL_INFO_10_194</key>

--- a/ui/00_message/ui/parameter.xml
+++ b/ui/00_message/ui/parameter.xml
@@ -1108,6 +1108,7 @@
   <message>
     <key>weakness_attack_armed</key>
     <original>対敵特効【戦甲】</original>
+    <translation>War-Ready Slayer</translation>
   </message>
   <message>
     <key>material_cateforyname_add_status</key>

--- a/ui/00_message/ui/pawn_cultivation.xml
+++ b/ui/00_message/ui/pawn_cultivation.xml
@@ -116,7 +116,7 @@
   <message>
     <key>pawn_cultivation_element_3_11</key>
     <original>体力が少しでも減れば回復する</original>
-    <translation>Heal teammates, even their the slightest wounds</translation>
+    <translation>Heal teammates' wounds, even their slightest ones</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_12</key>

--- a/ui/00_message/ui/pawn_cultivation.xml
+++ b/ui/00_message/ui/pawn_cultivation.xml
@@ -394,7 +394,7 @@ according to enemy condition</translation>
   <message>
     <key>pawn_growtalk_title_012</key>
     <original>優先度をどうしますか？</original>
-    <translation>How will you prioritize this?</translation>
+    <translation>How will you prioritize actions?</translation>
   </message>
   <message>
     <key>pawn_growtalk_title_013</key>

--- a/ui/00_message/ui/pawn_cultivation.xml
+++ b/ui/00_message/ui/pawn_cultivation.xml
@@ -117,12 +117,12 @@
   <message>
     <key>pawn_cultivation_element_3_11</key>
     <original>体力が少しでも減れば回復する</original>
-    <translation>Heal teammates' wounds, even their slightest ones</translation>
+    <translation>Heal teammates' wounds, even their smallest ones</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_12</key>
     <original>体力が少しでも減れば回復を受けにいく</original>
-    <translation>Seek healing, even for the slightest wounds</translation>
+    <translation>Seek healing, even for the smallest wounds</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_13</key>

--- a/ui/00_message/ui/pawn_cultivation.xml
+++ b/ui/00_message/ui/pawn_cultivation.xml
@@ -27,6 +27,7 @@
   <message>
     <key>pawn_cultivation_head_5</key>
     <original>敵との間合い</original>
+    <translation>Interaction with enemies</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_1_0</key>
@@ -66,7 +67,7 @@
   <message>
     <key>pawn_cultivation_element_3_1</key>
     <original>状態異常を回復する</original>
-    <translation>Cure status abnormalities</translation>
+    <translation>Cure debilitations</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_2</key>
@@ -106,7 +107,7 @@
   <message>
     <key>pawn_cultivation_element_3_9</key>
     <original>シークレットコアを発現する</original>
-    <translation>Reveal secret core</translation>
+    <translation>Expose secret core</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_10</key>
@@ -121,7 +122,7 @@
   <message>
     <key>pawn_cultivation_element_3_12</key>
     <original>体力が少しでも減れば回復を受けにいく</original>
-    <translation>Seek healing, even the slightest wounds</translation>
+    <translation>Seek healing, even for the slightest wounds</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_13</key>
@@ -131,10 +132,12 @@
   <message>
     <key>pawn_cultivation_element_4_0</key>
     <original>かなり支援寄り</original>
+    <translation>Support (↑↑)</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_4_1</key>
     <original>支援寄り</original>
+    <translation>Support (↑)</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_4_2</key>
@@ -144,30 +147,37 @@
   <message>
     <key>pawn_cultivation_element_4_3</key>
     <original>攻撃寄り</original>
+    <translation>Attack (↑)</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_4_4</key>
     <original>かなり攻撃寄り</original>
+    <translation>Attack (↑↑)</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_5_0</key>
     <original>かなり狭い</original>
+    <translation>Close (↑↑)</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_5_1</key>
     <original>狭い</original>
+    <translation>Close (↑)</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_5_2</key>
     <original>普通</original>
+    <translation>Normal</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_5_3</key>
     <original>広い</original>
+    <translation>Far (↑)</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_5_4</key>
     <original>かなり広い</original>
+    <translation>Far (↑↑)</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_0_0</key>
@@ -197,6 +207,7 @@
   <message>
     <key>pawn_growtalk_choice_006</key>
     <original>スタミナの使用頻度</original>
+    <translation>Stamina usage frequency</translation>
   </message>
   <message>
     <key>pawn_growtalk_choice_007</key>
@@ -413,10 +424,12 @@ according to enemy condition</translation>
   <message>
     <key>pawn_growtalk_title_018</key>
     <original>敵との間合いは？</original>
+    <translation>Distance to enemies</translation>
   </message>
   <message>
     <key>pawn_growtalk_title_019</key>
     <original>敵との間合いの最終確認</original>
+    <translation>Confirmation of distance to enemies</translation>
   </message>
   <message>
     <key>pawn_growtalk_title_020</key>
@@ -436,10 +449,12 @@ according to enemy condition</translation>
   <message>
     <key>pawn_growtalk_choice_049</key>
     <original>上げる</original>
+    <translation> (↑)</translation>
   </message>
   <message>
     <key>pawn_growtalk_choice_050</key>
     <original>下げる</original>
+    <translation> (↓)</translation>
   </message>
   <message>
     <key>pawn_growtalk_word_001</key>

--- a/ui/00_message/ui/pawn_cultivation.xml
+++ b/ui/00_message/ui/pawn_cultivation.xml
@@ -449,12 +449,12 @@ according to enemy condition</translation>
   <message>
     <key>pawn_growtalk_choice_049</key>
     <original>上げる</original>
-    <translation> (↑)</translation>
+    <translation>Increase</translation>
   </message>
   <message>
     <key>pawn_growtalk_choice_050</key>
     <original>下げる</original>
-    <translation> (↓)</translation>
+    <translation>Decrease</translation>
   </message>
   <message>
     <key>pawn_growtalk_word_001</key>

--- a/ui/00_message/ui/pawn_cultivation.xml
+++ b/ui/00_message/ui/pawn_cultivation.xml
@@ -61,6 +61,7 @@
   <message>
     <key>pawn_cultivation_element_3_0</key>
     <original>体力が危険な時に回復する</original>
+    <translation>Heal teammates when their health is critical</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_1</key>
@@ -70,10 +71,12 @@
   <message>
     <key>pawn_cultivation_element_3_2</key>
     <original>体力が危険な時に回復を受けにいく</original>
+    <translation>Seek healing when health is critical</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_3</key>
     <original>体力が少ない時に回復する</original>
+    <translation>Heal teammates when their health is low</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_4</key>
@@ -88,6 +91,7 @@
   <message>
     <key>pawn_cultivation_element_3_6</key>
     <original>体力が少ない時に回復を受けにいく</original>
+    <translation>Seek healing when health is low</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_7</key>
@@ -97,6 +101,7 @@
   <message>
     <key>pawn_cultivation_element_3_8</key>
     <original>敵の注目を集める</original>
+    <translation>Attract enemies</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_9</key>
@@ -111,11 +116,12 @@
   <message>
     <key>pawn_cultivation_element_3_11</key>
     <original>体力が少しでも減れば回復する</original>
+    <translation>Heal teammates, even their the slightest wounds</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_12</key>
     <original>体力が少しでも減れば回復を受けにいく</original>
-    <translation>Recover health even if it goes down a little</translation>
+    <translation>Seek healing, even the slightest wounds</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_3_13</key>
@@ -133,6 +139,7 @@
   <message>
     <key>pawn_cultivation_element_4_2</key>
     <original>普通</original>
+    <translation>Normal</translation>
   </message>
   <message>
     <key>pawn_cultivation_element_4_3</key>
@@ -224,6 +231,7 @@
   <message>
     <key>pawn_growtalk_choice_033</key>
     <original>攻撃の頻度を上げる</original>
+    <translation>Increase attack frequency</translation>
   </message>
   <message>
     <key>pawn_growtalk_choice_034</key>
@@ -233,11 +241,12 @@
   <message>
     <key>pawn_growtalk_choice_035</key>
     <original>敵との間合いをより取る</original>
-    <translation>Increase attack frequency</translation>
+    <translation>Keep distance from enemies</translation>
   </message>
   <message>
     <key>pawn_growtalk_choice_036</key>
     <original>敵との間合いをより詰める</original>
+    <translation>Stay close to enemies</translation>
   </message>
   <message>
     <key>pawn_growtalk_choice_037</key>
@@ -262,10 +271,12 @@
   <message>
     <key>pawn_growtalk_choice_041</key>
     <original>行動の優先度を上げる</original>
+    <translation>Increase priority of action</translation>
   </message>
   <message>
     <key>pawn_growtalk_choice_042</key>
     <original>行動の優先度を下げる</original>
+    <translation>Decrease priority of action</translation>
   </message>
   <message>
     <key>pawn_growtalk_choice_043</key>
@@ -310,6 +321,7 @@
   <message>
     <key>pawn_growtalk_err_005</key>
     <original>スキルを持っていないので選択できません</original>
+    <translation>Cannot select because this pawn does not possess the skill</translation>
   </message>
   <message>
     <key>pawn_growtalk_title_001</key>
@@ -349,6 +361,8 @@
   <message>
     <key>pawn_growtalk_title_008</key>
     <original>敵の大きさで使う技の最終確認</original>
+    <translation>Final confirmation of skill use
+according to enemy size</translation>
   </message>
   <message>
     <key>pawn_growtalk_title_009</key>
@@ -364,14 +378,17 @@ according to enemy condition</translation>
   <message>
     <key>pawn_growtalk_title_011</key>
     <original>行動の優先を変えたい項目を選択してください</original>
+    <translation>Please select the item you want to change priority</translation>
   </message>
   <message>
     <key>pawn_growtalk_title_012</key>
     <original>優先度をどうしますか？</original>
+    <translation>How will you prioritize this?</translation>
   </message>
   <message>
     <key>pawn_growtalk_title_013</key>
     <original>行動の優先の最終確認</original>
+    <translation>Final confirmation of priority of actions</translation>
   </message>
   <message>
     <key>pawn_growtalk_title_014</key>
@@ -381,10 +398,12 @@ according to enemy condition</translation>
   <message>
     <key>pawn_growtalk_title_015</key>
     <original>攻撃・支援の割合は？</original>
+    <translation>What is the attack/support ratio?</translation>
   </message>
   <message>
     <key>pawn_growtalk_title_016</key>
     <original>攻撃・支援の割合の最終確認</original>
+    <translation>Final confirmation of attack/support ratio</translation>
   </message>
   <message>
     <key>pawn_growtalk_title_017</key>

--- a/ui/00_message/ui/system_log.xml
+++ b/ui/00_message/ui/system_log.xml
@@ -1462,10 +1462,12 @@ CP報酬の有効クリア回数が上限に達しました</original>
   <message>
     <key>syslog_action_tornado_target</key>
     <original>&lt;NAME TARGET&gt; が竜巻に狙われている</original>
+    <translation>&lt;NAME TARGET&gt; has become the target of the tornado.</translation>
   </message>
   <message>
     <key>syslog_action_tornado_sign</key>
     <original>&lt;NAME TARGET&gt; が竜巻を起こそうとしている</original>
+    <translation>&lt;NAME TARGET&gt; is about to create a tornado.</translation>
   </message>
   <message>
     <key>syslog_action_humanhateup_target</key>
@@ -1484,6 +1486,7 @@ CP報酬の有効クリア回数が上限に達しました</original>
   <message>
     <key>syslog_action_fog_sign</key>
     <original>異界の霧が吐き零されていく――</original>
+    <translation>Otherworldly fog is spreading out...</translation>
   </message>
   <message>
     <key>syslog_action_alldestroy_rest_num</key>
@@ -1502,6 +1505,7 @@ CP報酬の有効クリア回数が上限に達しました</original>
   <message>
     <key>syslog_action_fog_clear</key>
     <original>殲滅に成功　異界の霧が晴れてゆく――</original>
+    <translation>Successfully destroyed. The otherworldly fog is clearing up</translation>
   </message>
   <message>
     <key>syslog_bo_get_ex</key>


### PR DESCRIPTION
- Fully translated pawn_cultivation.xml (Pawn Training) and fixed some bugs from previous pull request.
- Fixed errors in some EX skills' description and an augment (Perky).
- Translate some leftover augments (Supreme Jewelry ones) and some messages.
- Change all 'Elixer' and 'Elixir' to be 'Elixir'.
- Change an enemy type in augment name to make more sense: Rock becomes (Magickal) Construct.

Note: There's also a proposed change for 'Ogre' to become 'Demon' and 'Demon' to become 'Fiend' (according to the english wiki). This is due to the fact that the original word for Ogre is Oni in Japanese, but Orcs are included in this group as well so calling Orcs 'Ogres' does not make sense. I'm still not sure whether to change this or not because people may have been used to the old names. For now, I'm leaving it as it is but if any new future monsters do not fit in this group again or when people really want the change, I'll switch the names around.
