### PR TITLE
New skills - 3.3

### DIFF
--- a/ui/00_message/skill/ability_info.toml
+++ b/ui/00_message/skill/ability_info.toml
@@ -101,7 +101,7 @@ old = '''
 <COL ffdc78>LV UP毎により減退速度がさらに低下</COL>'''
 new = '''
 Slows the drain of Magick Glyph.
-<COL ffdc78>LV UP: Further decreases the drain.下</COL>'''
+<COL ffdc78>LV UP: Further decreases the drain.</COL>'''
 [[message]]
 key = 'ABILITY_INFO_4'
 old = '''

--- a/ui/00_message/skill/custom_skill_command_01.toml
+++ b/ui/00_message/skill/custom_skill_command_01.toml
@@ -25,7 +25,9 @@ old = '''
 <COL ff7878>威力が最大となる高度からの攻撃で
 戦甲へのカウンターに特化</COL> '''
 # NEEDS REVIEW
-new = 'Press the assigned button.'
+new = '''Press the assigned button.
+<COL ff7878>Effective against War-Ready enemies if this skill is executed
+from high position.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_COMMAND_01_11'
 old = 'セットボタンを連続して押す'

--- a/ui/00_message/skill/custom_skill_command_03.toml
+++ b/ui/00_message/skill/custom_skill_command_03.toml
@@ -49,7 +49,9 @@ old = '''
 <COL ff7878>溜め満了の瞬間に放つことで
 戦甲へのカウンターに特化</COL>'''
 # NEEDS REVIEW
-new = 'While holding the assigned button, <KC SHOOT> to shoot.'
+new = '''While holding the assigned button, <KC SHOOT> to shoot.
+<COL ff7878>Effective against War-Ready enemies if this skill is executed
+just as the charge gauge is full.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_COMMAND_03_131'
 old = '''

--- a/ui/00_message/skill/custom_skill_command_07.toml
+++ b/ui/00_message/skill/custom_skill_command_07.toml
@@ -52,7 +52,9 @@ old = '''
 セットボタン押しっぱなし
 <COL ff7878>溜め満了で戦甲へのカウンターに特化</COL>'''
 # NEEDS REVIEW
-new = 'Hold the assigned button.'
+new = '''Hold the assigned button.
+<COL ff7878>Effective against War-Ready enemies if this skill is executed
+at full gauge.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_COMMAND_07_139'
 old = 'しがみつき中にセットボタンを押す'

--- a/ui/00_message/skill/custom_skill_command_09.toml
+++ b/ui/00_message/skill/custom_skill_command_09.toml
@@ -42,7 +42,9 @@ old = '''
 <COL ff7878>錬成値が最大の状態での発動で
 戦甲へのカウンターに特化</COL>'''
 # NEEDS REVIEW
-new = 'Press the assigned button.'
+new = '''Press the assigned button.
+<COL ff7878>Effective against War-Ready enemies if this skill is executed
+on a full elixir stack.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_COMMAND_09_113'
 old = 'セットボタンを押す'

--- a/ui/00_message/skill/custom_skill_command_10.toml
+++ b/ui/00_message/skill/custom_skill_command_10.toml
@@ -74,8 +74,9 @@ old = '''
 new = '''
 Press the assigned button.
 After forming the barrier, press the assigned button
-to release energy.
-Further enhanced with Attack Boost.'''
+to release energy. Further enhanced with Attack Boost.
+<COL ff7878>Effective against War-Ready enemies if this skill is executed
+at maximum spiritual accumulation.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_COMMAND_10_153'
 old = '''

--- a/ui/00_message/skill/custom_skill_command_11.toml
+++ b/ui/00_message/skill/custom_skill_command_11.toml
@@ -63,3 +63,8 @@ old = '''
 発動後、再度セットボタンを押すと攻撃
 　カテゴリ：補助魔法
 　魔力４スタック消費で発動可能'''
+new = '''
+Press the assigned button.
+After invocation, press the assigned button again to attack
+　Category: Support Magick.
+　Consumes 4 magick stacks on activation.'''

--- a/ui/00_message/skill/custom_skill_info_01.toml
+++ b/ui/00_message/skill/custom_skill_info_01.toml
@@ -270,9 +270,18 @@ old = '''
 ダメージ量が増加
 攻撃回数が増す度に剣を振る速度が上昇
 最大攻撃回数増加'''
+new = '''
+EX Additional Effects:
+Increase damage.
+Increase attack speed as the number of attack increases.
+Increase maximum number of attacks.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_01_212'
 old = '''
 【ＥＸ追加効果】
 攻撃範囲が大幅に拡張
 吹き飛ばし力増加'''
+new = '''
+EX Additional Effects:
+Greatly extend attack range.
+Increase blow power.'''

--- a/ui/00_message/skill/custom_skill_info_01.toml
+++ b/ui/00_message/skill/custom_skill_info_01.toml
@@ -75,7 +75,6 @@ old = '''
 LV.６で攻撃ヒット数増加</COL> '''
 new = '''
 Leap forward and stab your sword into the ground.
-<COL ff7878>Effective against War-Ready enemies.</COL>
 <COL ffdc78>LV UP: Increases damage.
 LV.6: Increases number of hits.</COL>'''
 [[message]]
@@ -198,8 +197,9 @@ new = '''
 EX Additional Effects:
 Increase damage.
 Increase number of hits.
-Slightly increase chance attack and Fatigue attack.
-<COL ff7878>Further increase damage to Human/Dragonkin/Alchemized type enemies.</COL>'''
+Slightly increase Chance attack and Fatigue attack.
+<COL ff7878>Further increase damage to
+Human/Dragonkin/Alchemized type enemies.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_01_155'
 old = '''

--- a/ui/00_message/skill/custom_skill_info_02.toml
+++ b/ui/00_message/skill/custom_skill_info_02.toml
@@ -258,6 +258,10 @@ old = '''
 【ＥＸ追加効果】
 モーションが変化し、短剣による攻撃回数が増加
 爆発の攻撃ヒット数が増加'''
+new = '''
+EX Additional Effects:
+Change motion, increase number of dagger attacks.
+Increase number of explosion hits.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_02_216'
 old = '''
@@ -265,3 +269,8 @@ old = '''
 斬り上げと爆発の攻撃範囲が拡張
 爆発に炎防低下の状態異常が付与され
 延焼の状態異常蓄積値も増加'''
+new = '''
+EX Additional Effects:
+Increase range of dagger slash and explosion.
+Add Fire Resist Down accumulation to explosion hits.
+Increase Burn accumulation.'''

--- a/ui/00_message/skill/custom_skill_info_03.toml
+++ b/ui/00_message/skill/custom_skill_info_03.toml
@@ -146,9 +146,9 @@ old = '''
 LV.６で溜め時間短縮</COL>'''
 new = '''
 Draw the bow back with all your might and loose an arrow
-of extraordinary power. Further increase damage if fired just as the charge is
-completed. The lower the enemy's health, the higher the damage of this skill.
-<COL ff7878>Effective against War-Ready enemies.</COL>
+of extraordinary power. Further increase damage if fired
+just as the charge is completed. The lower the enemy's
+health, the higher the damage of this skill.
 <COL ffdc78>LV UP: Increases damage of the skill.
 LV.6: Decreases charge time.</COL>'''
 [[message]]
@@ -161,8 +161,8 @@ old = '''
 LV.６で爆発回数増加</COL>'''
 new = '''
 Loose an arrow wrapped with explosive powder into
-the sky. Detonation altitude rises the longer the button is held
-while firing.
+the sky. Detonation altitude rises the longer the button is
+held while firing.
 <COL ffdc78>LV UP: Increases damage of the skill.
 LV.6: Increases the number of explosions.</COL>'''
 [[message]]
@@ -174,12 +174,12 @@ old = '''
 LV.６で溜め段階上昇（２→３）
 ボタン入力回数減少</COL>'''
 new = '''
-Tightly bind together all the arrows in the quiver,
-and unleash them with your entire body's might.
+Tightly bind together all the arrows in the quiver, and
+unleash them with your entire body's might.
 Can be activated while climbing an enemy.
 <COL ffdc78>LV UP: Increases damage of the skill.
-LV.6: Increases maximum charge (2→3) and reduces number of button presses
-needed to advance to the next level of charge.</COL>'''
+LV.6: Increases maximum charge (2→3) and reduces number of
+button presses needed to advance to the next level of charge.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_03_162'
 old = '''
@@ -237,7 +237,7 @@ old = '''
 溜め段階２の攻撃ヒット数が増加'''
 new = '''
 EX Additional Effects:
-Increase number of hits.'''
+Increase number of hits on second charge.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_03_198'
 old = '''
@@ -257,6 +257,11 @@ old = '''
 溜め時間短縮
 起爆時の爆発ダメージ量が増加
 溜め２段階で、中央の爆発の攻撃ヒット数が増加'''
+new = '''
+EX Additional Effects:
+Reduce charge time.
+Increase explosion damage.
+Increase number of hits at the center on second charge.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_03_200'
 old = '''
@@ -265,3 +270,8 @@ old = '''
 爆薬矢に継続ダメージを付与
 攻撃により起爆しなくなり
 時間による起爆時の威力が増加'''
+new = '''
+EX Additional Effects:
+Reduce charge time.
+Arrows deal continuous damage.
+Arrows cannot be detonated by attack.'''

--- a/ui/00_message/skill/custom_skill_info_04.toml
+++ b/ui/00_message/skill/custom_skill_info_04.toml
@@ -253,15 +253,22 @@ new = '''
 EX Additional Effects:
 When enter the magick area, the curing effect
 lingers for an amount of time.
-Increase the number of magick spot you can deploy (1→2)'''
+Increase the number of magick spots you can deploy (1→2)'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_04_219'
 old = '''
 【ＥＸ追加効果】
 フィールドシフト時、
 １度だけ攻撃を無効化する魔球を付与'''
+new = '''
+EX Additional Effects:
+When Field Shifting, grant each ally one magick sphere that
+nullifies one attack.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_04_220'
 old = '''
 【ＥＸ追加効果】
 風圧と地震を無効にする'''
+new = '''
+EX Additional Effects:
+Nullify Wind Pressure and Tremor.'''

--- a/ui/00_message/skill/custom_skill_info_04.toml
+++ b/ui/00_message/skill/custom_skill_info_04.toml
@@ -175,10 +175,11 @@ old = '''
 <COL ffdc78>LV UP毎に魔法砲台の出現時間延長
 LV.６で魔法球の威力上昇／魔法砲台増加（１→２）</COL>'''
 new = '''
-Call forth a magickal orb that acts as a turret and
-when hit by Blast Bit, will generate additional Blast Bits from itself.
+Call forth a magickal orb that acts as a turret and when hit
+by Blast Bit, will generate additional Blast Bits from itself.
 <COL ffdc78>LV UP: Increases duration of the magickal orb.
-LV.6: Increases the damage of the magickal orb, and the amount that are placed (1→2)</COL>'''
+LV.6: Increases the damage of the magickal orb, and the amount
+that are placed (1→2)</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_04_166'
 old = '''
@@ -251,7 +252,8 @@ old = '''
 new = '''
 EX Additional Effects:
 When enter the magick area, the curing effect
-lingers for an amount of time.'''
+lingers for an amount of time.
+Increase the number of magick spot you can deploy (1→2)'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_04_219'
 old = '''

--- a/ui/00_message/skill/custom_skill_info_05.toml
+++ b/ui/00_message/skill/custom_skill_info_05.toml
@@ -157,8 +157,8 @@ Fire a magickal anchor towards a foe, and gradually
 fill the force gauge and aggression meter if it hits.
 While the anchor is active, you can move in any direction
 with <PADM>the left stick.<KEYM>the movement keys.</KEYM>
-<COL ffdc78>LV UP: Decreases stamina consumption for each additional hit while
-the anchor is active.
+<COL ffdc78>LV UP: Decreases stamina consumption for each additional
+hit while the anchor is active.
 LV.6: Increases range of the skill.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_05_136'
@@ -268,8 +268,17 @@ old = '''
 展開中に魔法の壁を解放して聖属性の攻撃が可能
 敵の攻撃を防ぐと魔法の壁のエネルギーが蓄積し
 解放時のダメージ量が増加する'''
+new = '''
+EX Additional Effects:
+Reduce charge time.
+Can release magick wall and attack surrounding enemies.
+Blocking attacks will accumulate the energy of the wall,
+increasing damage.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_05_208'
 old = '''
 【ＥＸ追加効果】
 展開中、物理防御力／魔法防御力／耐久力が増加'''
+new = '''
+EX Additional Effects:
+Increase Physical/Magick defense and Endurance.'''

--- a/ui/00_message/skill/custom_skill_info_05.toml
+++ b/ui/00_message/skill/custom_skill_info_05.toml
@@ -155,8 +155,8 @@ LV.６で射程距離延長</COL>'''
 new = '''
 Fire a magickal anchor towards a foe, and gradually
 fill the force gauge and aggression meter if it hits.
-While the anchor is active, you can move in any direction with 
-<PADM>the left stick.<KEYM>the movement keys.</KEYM>
+While the anchor is active, you can move in any direction
+with <PADM>the left stick.<KEYM>the movement keys.</KEYM>
 <COL ffdc78>LV UP: Decreases stamina consumption for each additional hit while
 the anchor is active.
 LV.6: Increases range of the skill.</COL>'''
@@ -169,10 +169,10 @@ old = '''
 <COL ffdc78>LV UP毎に石化の異常値上昇
 LV.６で照射範囲拡大</COL>'''
 new = '''
-Keep the rod focused on an enemy, and radiate
-a light that builds up the Petrified status abnormality on them.
-When the Force Gauge has one or more charges, they will be automatically
-consumed to increase the performance of the skill.
+Keep the rod focused on an enemy, and radiate a light that
+builds up the Petrified status abnormality on them.
+When the Force Gauge has one or more charges, they will be
+automatically consumed to increase the skill's performance.
 <COL ffdc78>LV UP: Increases Petrified status accumulation.
 LV.6: Increases the range of the light.</COL>'''
 [[message]]
@@ -184,10 +184,10 @@ old = '''
 <COL ffdc78>LV UP毎に攻撃威力の上昇
 LV.６で盾ガード値上昇／ヒット数増加</COL>'''
 new = '''
-Shake the Greatshield about while running around enemies, preventing their attacks
-and increasing aggression.
-When the Force Gauge has one or more charges, they will be automatically
-consumed to increase the performance of the skill.
+Shake the Greatshield about while running around enemies,
+preventing their attacks and increasing aggression.
+When the Force Gauge has one or more charges, they will be
+automatically consumed to increase the skill's performance.
 <COL ffdc78>LV UP: Increases damage of the skill.
 LV.6: Increases Guard Power and number of hits.</COL>'''
 [[message]]
@@ -210,7 +210,8 @@ old = '''
 new = '''
 EX Additional Effects:
 Attract enemies within the area.
-Cause status abnormality of the currently enchanted element of your weapon.'''
+Cause status abnormality of the currently enchanted element
+of your weapon.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_05_172'
 old = '''

--- a/ui/00_message/skill/custom_skill_info_06.toml
+++ b/ui/00_message/skill/custom_skill_info_06.toml
@@ -240,9 +240,17 @@ old = '''
 【ＥＸ追加効果】
 攻撃ヒット数が増加
 凍結の状態異常蓄積値が増加'''
+new = '''
+EX Additional Effects:
+Increase number of hits.
+Increase Freeze accumulation.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_06_224'
 old = '''
 【ＥＸ追加効果】
 氷の塊消滅後、氷粒の渦を展開
 氷防低下の状態異常を付与'''
+new = '''
+EX Additional Effects:
+Leave an icy vortex after the ice pillar disappears.
+Add Ice Resist Down accumulation.'''

--- a/ui/00_message/skill/custom_skill_info_06.toml
+++ b/ui/00_message/skill/custom_skill_info_06.toml
@@ -145,10 +145,10 @@ old = '''
 <COL ffdc78>LV UP毎に攻撃威力の上昇
 LV.６で爆発範囲の限界幅が拡張</COL>'''
 new = '''
-After charging magick, conjure a non-elemental
-magick orb. The magickal power stored within the orb is released over
-a wide area, dealing a great deal of damage to foes within its range.
-Especially effective in narrow areas.
+After charging magick, conjure a non-elemental magick orb.
+The magickal power stored within the orb is released over
+an adjustable area, dealing a great deal of damage to foes
+within its range. Power increases as the orb becomes smaller.
 <COL ffdc78>LV UP: Increases damage of the skill.
 LV.6: Expands the range of the explosion.</COL>'''
 [[message]]
@@ -172,8 +172,8 @@ old = '''
 <COL ffdc78>LV UP毎にスタミナ消費量の減少
 LV.６で攻撃威力上昇／攻撃ヒット数増加</COL>'''
 new = '''
-Conjure a magickal stake that gathers magickal power from your staff,
-and calls down lightning when charged.    
+Conjure a magickal stake that gathers magickal power from
+your staff, and calls down lightning when charged.    
 <COL ffdc78>LV UP: Decreases stamina cost of skill.
 LV.6: Increases damage of the skill and number of hits.</COL>'''
 [[message]]

--- a/ui/00_message/skill/custom_skill_info_07.toml
+++ b/ui/00_message/skill/custom_skill_info_07.toml
@@ -270,9 +270,17 @@ old = '''
 【ＥＸ追加効果】
 モーションが変化し、攻撃ヒット数が増加
 のけぞり中にも発動可能'''
+new = '''
+EX Additional Effects:
+Change motions, increase the number of hits.
+Can be used when staggered.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_07_228'
 old = '''
 【ＥＸ追加効果】
 吹き飛ばし力が増加
 前方への攻撃範囲が大幅に拡張'''
+new = '''
+EX Additional Effects:
+Increase blow power.
+Extend the range of the attack forward.'''

--- a/ui/00_message/skill/custom_skill_info_07.toml
+++ b/ui/00_message/skill/custom_skill_info_07.toml
@@ -156,10 +156,9 @@ LV.６で剣に風圧が追加／攻撃ヒット数増加</COL>'''
 new = '''
 After channeling enough energy, release
 a devastating slash with your body's entire might.
-<COL ff7878>Effective against War-Ready enemies.</COL>
 <COL ffdc78>LV UP: Increases damage of skill.
-LV.6: Adds wind pressure to the blade and increases number of
-hits.</COL>'''
+LV.6: Adds wind pressure to the blade and increases number
+of hits.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_07_139'
 old = '''

--- a/ui/00_message/skill/custom_skill_info_08.toml
+++ b/ui/00_message/skill/custom_skill_info_08.toml
@@ -156,9 +156,9 @@ new = '''
 After gathering sufficient magickal power, let loose
 an extraordinarily powerful Holy arrow.
 The arrow can be controlled mid-flight with the <PADM>Left Stick<KEYM>Movement Keys</KEYM>.
-The power of the skill depends on the max stamina available. The spot
-that is hit will automatically be targeted by magickal arrows for a period
-of time.
+The power of the skill depends on the stamina available.
+The hit spot will automatically be targeted by the magickal
+arrows for a while.
 <COL ffdc78>LV UP: Increases damage and cast speed of the skill.
 LV.6: Increases number of hits.</COL>
 '''
@@ -172,8 +172,9 @@ old = '''
 LV.６で起爆時の閃光効果強化</COL>'''
 new = '''
 Let loose a holy magickal arrow imbued with the power to heal
-into the sky and detonate it. The arrow emits a strong flash at the time of detonation,
-and those within its light recover a portion of health.(Damages Undead)
+into the sky and detonate it. The arrow emits a strong flash at
+the time of detonation, recovering a portion of health for allies.
+(Damages Undead)
 <COL ffdc78>LV UP: Increases health recovery amount.
 LV.6: Increases the power of the flash at detonation.</COL>'''
 [[message]]
@@ -191,9 +192,10 @@ old = '''
 <COL ffdc78>LV UP毎に攻撃威力の上昇
 LV.６で連鎖回数増加</COL>'''
 new = '''
-Let loose a dark magickal arrow that tears apart the enemy it
-contacts with tentacles. The tentacles will seek out additional enemies, and 
-attack them. Effective for destroying Infected Sprouts.
+Let loose a magickal arrow that tears apart the enemy it contacts
+with tentacles. The tentacles will seek out additional enemies or
+continue to attack current target depending on its size. 
+Effective for destroying Infected Sprouts.
 <COL ffdc78>LV UP: Increases damage of skill.
 LV.6: Increases the target chain amount.</COL>'''
 [[message]]

--- a/ui/00_message/skill/custom_skill_info_08.toml
+++ b/ui/00_message/skill/custom_skill_info_08.toml
@@ -274,6 +274,11 @@ old = '''
 闇属性のダメージが追加
 溜め時間短縮
 ターゲット数増加（５→７）'''
+new = '''
+EX Additional Effects:
+Add Dark-attribute damage.
+Reduce charge time.
+Increase the number of target locks (5→7).'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_08_204'
 old = '''
@@ -281,3 +286,9 @@ old = '''
 最適距離の範囲が拡張
 魔道弓に付与されている属性の
 防御力を低下させる状態異常を付与'''
+new = '''
+EX Additional Effects:
+Extend the optimal range.
+Add Elemental Resist Down accumulation that matches your
+weapon's element.
+'''

--- a/ui/00_message/skill/custom_skill_info_09.toml
+++ b/ui/00_message/skill/custom_skill_info_09.toml
@@ -41,10 +41,8 @@ new = '''
 Create an elemental orb that bestows one of the
 three main attributes of fire, ice, or lightning,
 from the ground and place it in the air.
-<COL ffdc78>LV UP: Increases duration of
-the skill.
-LV.6: Unlocks the final two elements, Holy and
-Darkness.</COL>'''
+<COL ffdc78>LV UP: Increases duration of the skill.
+LV.6: Unlocks the final two elements, Holy and Darkness.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_09_109'
 old = '''
@@ -99,8 +97,7 @@ new = '''
 Generate a trap from an alchemical substance.
 When enemies approach the trap, pillars spike out
 from it and penetrate them.
-<COL ffdc78>LV UP: Increases number of
-trap activations.
+<COL ffdc78>LV UP: Increases number of trap activations.
 LV.6: Increases the number of pillar spikes (1→3)</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_09_111'
@@ -111,13 +108,11 @@ old = '''
 <COL ffdc78>LV UP毎に黄金化の異常値上昇
 LV.６でダウン、拘束中を除きいつでも発動可能</COL>'''
 new = '''
-Coat yourself in gold and deflect enemy attacks.
-Enemies that attack will build up the "Gilded"
-status abnormality.
+Coat yourself in gold and deflect enemy attacks. Enemies
+that attack will build up the "Gilded" status abnormality.
 Can be activated even while in the air.
 <COL ffdc78>LV UP: Increases rate of Gilding build-up.
-LV.6: Can activate the skill at anytime except
-when grabbed.</COL>'''
+LV.6: Can activate the skill at anytime except when grabbed.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_09_112'
 old = '''
@@ -126,11 +121,8 @@ old = '''
 <COL ffdc78>LV UP毎に攻撃威力の上昇
 LV.６でヒット数増加／爆発に周囲の敵を巻き込む</COL>'''
 new = '''
-Form a giant alchemical arm to strike the enemy
-directly. If it hits an alchemical stake, the attack
-will unleash alchemical substances and cause a
-giant explosion. Can be activated while climbing an enemy.
-<COL ff7878>Effective against War-Ready enemies.</COL>
+Directly strike the enemy and detonate alchemical stake on
+target, creating a large explosion. Can be used when climbing.
 <COL ffdc78>LV UP: Increases damage of skill.
 LV.6: Increases number of hits and the surrounding
 enemies are affected by the explosion.</COL>'''
@@ -158,10 +150,8 @@ new = '''
 Shoot alchemical substances radially toward you.
 If you are close to the enemies, all substances will hit.
 Can be activated in mid-air.
-<COL ffdc78>LV UP: Increase damage.
-LV.6: Increase range.
-Increase the number of substances (3→5)</COL>
-    '''
+<COL ffdc78>LV UP: Increases damage.
+LV.6: Increases range and the number of substances (3→5)</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_09_115'
 old = '''
@@ -171,11 +161,11 @@ old = '''
 <COL ffdc78>LV UP毎に状態異常値上昇
 LV.６で最大入力回数が増加し、展開時間が延長</COL>'''
 new = '''
-Generate an area that nullifies damage for all allies nearby.
+Generate an area that nullifies damage for all allies inside.
 Enemies within the area are affected by your chosen Elixir.
 The duration is greatly increased with correct timing.
 <COL ffdc78>LV UP: Increases debilitation rate.
-LV.6: Maximum number of inputs increased, extending the duration.</COL>'''
+LV.6: Number of inputs increased, extending the duration.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_09_189'
 old = '''
@@ -210,7 +200,8 @@ new = '''
 EX Additional Effects:
 Increase damage.
 Add Gilded status abnormality.
-<COL ff7878>Further increase damage against Human/Dragonkin/Alchemized enemies.</COL>
+<COL ff7878>Further increase damage against
+Human/Dragonkin/Alchemized enemies.</COL>
 '''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_09_192'
@@ -238,8 +229,8 @@ EX Additional Effects:
 May employ strengthened alchemical substances that deal
 more damage and has faster alchemical buildup.
 Normal alchemical substance has a chance to be strengthened.
-If used in conjunction with Counterra Aurum, all substances are
-strengthened.'''
+If used in conjunction with Counterra Aurum, all substances
+are strengthened.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_09_230'
 old = '''

--- a/ui/00_message/skill/custom_skill_info_09.toml
+++ b/ui/00_message/skill/custom_skill_info_09.toml
@@ -251,8 +251,16 @@ old = '''
 エンチャントの効果を受けると
 自身のみエンチャント属性の状態異常蓄積値が
 大幅に増加'''
+new = '''
+EX Additional Effects:
+When you receive the enchant from this skill, elemental
+debilitation is greatly increased only on yourself.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_09_232'
 old = '''
 【ＥＸ追加効果】
 設置時のみ広範囲にエンチャント効果を付与'''
+new = '''
+EX Additional Effects:
+Grant enchantment to surrounding allies when you place the
+orb.'''

--- a/ui/00_message/skill/custom_skill_info_10.toml
+++ b/ui/00_message/skill/custom_skill_info_10.toml
@@ -70,9 +70,9 @@ old = '''
 <COL ffdc78>LV UP毎に攻撃威力の上昇
 LV.６で霊力最大の起爆ヒット数増加／溜まる霊力増加</COL> '''
 new = '''
-Form a spirit orb that generates shockwaves
-when attacked. The orb gathers spiritual energy when attacked.
-It can also be detonated both on the ground and mid-air manually.
+Form a spirit orb that generates shockwaves when attacked.
+The orb gathers spiritual energy when attacked. It can also
+be detonated both on the ground and mid-air manually.
 <COL ffdc78>LV UP: Increases damage of skill.
 LV.6: Increases maximum hits of the detonation and amount of
 spirit energy gained.</COL>'''
@@ -85,10 +85,9 @@ old = '''
 <COL ffdc78>LV UP毎に展開時間延長
 LV.６で展開エリアの最大サイズが拡張</COL>'''
 new = '''
-Form spiritual spheres around yourself that
-recovers health and status abnormalities. The range grows depending
-on the charge time. The effectiveness of the skill rises upon a full
-charge.
+Form spiritual spheres around yourself that recovers health
+and status abnormalities. The range grows dependingon the
+charge time. The effectiveness rises upon a full charge.
 <COL ffdc78>LV UP: Increases duration of skill.
 LV.6: Increases the area of effect of the skill.</COL>'''
 [[message]]
@@ -100,11 +99,10 @@ old = '''
 <COL ffdc78>LV UP毎に攻撃威力の上昇／バリア展開時間延長
 LV.６でバリアの耐久値増加（１→２）</COL>'''
 new = '''
-Form a barrier around yourself to prevent
-enemy attacks. When attacking enemies while the barrier is active,
-spiritual energy gathers in the barrier. You can unleash the energy
+Form a barrier around yourself to prevent enemy attacks.
+When attacking enemies while the barrier is active, spiritual
+energy gathers in the barrier. You can unleash the energy
 by pressing the assigned button.
-<COL ff7878>Effective against War-Ready enemies.</COL>
 <COL ffdc78>LV UP: Increases damage of skill and duration.
 LV.6: Increase maximum barrier durability (1→2)</COL>'''
 [[message]]
@@ -116,11 +114,11 @@ old = '''
 LV.６でモーション変化／攻撃ヒット数増加</COL>'''
 new = '''
 A high power skill that covers a wide area.
-If the first hit is successfully landed, it will become a full on
-combo attack.
+If the first hit is successfully landed, it will become
+a full on combo attack.
 <COL ffdc78>LV UP: Increases damage of the skill.
-LV.6: Increases the number of hits in the attack, and changes
-the motion of the skill.</COL>'''
+LV.6: Increases the number of hits in the attack, and
+changes the motion of the skill.</COL>'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_10_188'
 old = '''
@@ -130,9 +128,9 @@ old = '''
 <COL ffdc78>LV UP毎に効果時間延長
 LV.６でエンチャント強化と吹き飛ばし力強化の性能上昇</COL>'''
 new = '''
-Expand a spiritual area that increases damage and
-blow force of enchantment of nearby allies including enchantment
-from crests. If used as a counter, the effect is greatly increased
+Expand a spiritual area that increases damage and blow force
+of enchantment of nearby allies including enchantment from
+crests. If used as a counter, the effect is greatly increased
 and the deployment size is expanded.
 <COL ffdc78>LV UP: Increases duration of effect.
 LV.6: Increases the effectiveness of the buff.</COL>'''
@@ -175,7 +173,8 @@ old = '''
 スピリットゲージ蓄積量が増加'''
 new = '''
 EX Additional Effects:
-Possible to activate in the air without executing the first hit.
+Possible to activate in the air without
+executing the first hit.
 Increase Spirit Gauge accumulation.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_10_233'
@@ -201,8 +200,15 @@ old = '''
 【ＥＸ追加効果】
 治癒上限値を徐々に回復する
 ヒールブースト時の攻撃力の上昇量が増加'''
+new = '''
+EX Additional Effects:
+Gradually recover the healable limit of allies.
+Further increase attack power during Heal Boost.'''
 [[message]]
 key = 'CUSTOM_SKILL_INFO_10_236'
 old = '''
 【ＥＸ追加効果】
 耐久力を強化する効果を付与'''
+new = '''
+EX Additional Effects:
+Increase Endurance for allies inside.'''

--- a/ui/00_message/skill/custom_skill_info_11.toml
+++ b/ui/00_message/skill/custom_skill_info_11.toml
@@ -64,7 +64,7 @@ old = '''
 <COL ffdc78>LV UP毎に展開時間延長
 LV.6で敵の攻撃に合わせて発動した際、展開時間延長</COL>'''
 new = '''
-Create a magickal barrier in front of youfor a certain amount of
+Create a magickal barrier in front of you for a certain amount of
 time. Barrier duration does not decrease when using pure magick.
 <COL ffdc78>LV UP: Increases duration of the barrier.
 LV.6 When invoked just before an enemy's attack connects,

--- a/ui/00_message/skill/custom_skill_info_11.toml
+++ b/ui/00_message/skill/custom_skill_info_11.toml
@@ -22,7 +22,7 @@ LV.6で攻撃アクション中であればいつでも発動可能</COL>'''
 new = '''
 Create a phantom and teleport forward.
 If user comes into contact with enemy
-while teleporting, deal magic damage.
+while teleporting, deal magick damage.
 Can use twice while mid air.
 <COL ffdc78>LV UP Reduce cooldown between activation.
 LV.6 Can be used at any time during attack.</COL>'''
@@ -35,7 +35,7 @@ old = '''
 LV.6で攻撃ヒット回数が増加</COL>'''
 new = '''
 Ready your sword and slice downwards, releases several
-magic blades towards enemies infont of you.
+magick blades towards enemies infont of you.
 <COL ffdc78>LV UP Increases damage of skill.
 LV.6 Increases number of hit.</COL>'''
 [[message]]
@@ -64,9 +64,9 @@ old = '''
 <COL ffdc78>LV UP毎に展開時間延長
 LV.6で敵の攻撃に合わせて発動した際、展開時間延長</COL>'''
 new = '''
-Create a magickal barrier in front of you
-for a certain amount of time.
-<COL ffdc78>LV UP: Increases duration of the shield.
+Create a magickal barrier in front of youfor a certain amount of
+time. Barrier duration does not decrease when using pure magick.
+<COL ffdc78>LV UP: Increases duration of the barrier.
 LV.6 When invoked just before an enemy's attack connects,
 duration is further increased.</COL>'''
 [[message]]
@@ -101,3 +101,10 @@ old = '''
 魔力吸収特化の一撃を放つ。発動中は魔力を消費し続ける
 <COL ffdc78>LV UP毎に発動中の魔力消費量が減少
 LV.6で再入力時の攻撃回数による強化段階が増加（１→２）'''
+new = '''
+Imbue magickal power on your sword, adding afterimage to the
+core sword skills. Press the assigned button again to release
+an attack that absorbs an amount of magick based on the number
+of afterimage attacks. Slowly drain magick during activation.
+<COL ffdc78>LV UP Reduces magick drain during activation.
+Lv.6 Increases maximum number of charges from attacks (1→2).</COL>'''


### PR DESCRIPTION
- Translate the description of new EX skills in 3.3 and Phantom Edge.
- Update some old descriptions that were recently updated by Capcom.
- Try to rearrange some descriptions layout so they are not too 'squished'. In general, I try to keep at most 60 characters per line and a maximum of 5 lines in each description so they don't become too small or go past to the command section. There are cases which I need to go past those limits though.
- Redo the description of Alchemical Burst since it doesn't really match the original description (and too long to fit in)
- Move the 'Effective against War-Ready' lines down to the command section to match with the official change.