### PR TITLE
Misc 3 4

### DIFF
--- a/ui/00_message/common/condition_name.toml
+++ b/ui/00_message/common/condition_name.toml
@@ -213,21 +213,28 @@ new = 'Spirited Away'
 [[message]]
 key = 'CONDITION_NAME_65'
 old = '寄生毒'
+new = 'Parasitic Poison'
 [[message]]
 key = 'CONDITION_NAME_66'
 old = '寄生毒'
+new = 'Parasitic Poison'
 [[message]]
 key = 'CONDITION_NAME_67'
 old = '抗蟲状態'
+new = 'Parasitic Poison Resist'
 [[message]]
 key = 'CONDITION_NAME_68'
 old = '全攻撃能力上昇'
+new = 'Extreme Attack Up'
 [[message]]
 key = 'CONDITION_NAME_69'
 old = '全防御能力上昇'
+new = 'Extreme Defense Up'
 [[message]]
 key = 'CONDITION_NAME_70'
 old = '闇炎'
+new = 'Dark Flame'
 [[message]]
 key = 'CONDITION_NAME_71'
 old = '闇牢'
+new = 'Dark Prison'

--- a/ui/00_message/daily_mission/task_list_2.toml
+++ b/ui/00_message/daily_mission/task_list_2.toml
@@ -1,6 +1,7 @@
 ﻿[[message]]
 key = 'DAILY_MISSION_TASK_40'
 old = '滅びの渦で暗黒の大竜晶を破壊する'
+new = 'Destroy the Dark Dragon Crystal in the Vortex of Ruin'
 [[message]]
 key = 'DAILY_MISSION_TASK_42'
 old = '''

--- a/ui/00_message/daily_mission/task_list_3.toml
+++ b/ui/00_message/daily_mission/task_list_3.toml
@@ -1,27 +1,36 @@
 ﻿[[message]]
 key = 'DAILY_MISSION_TASK_12'
 old = '滅びの渦で暗黒の大竜晶を破壊する'
+new = 'Destroy the Dark Dragon Crystal in the Vortex of Ruin'
 [[message]]
 key = 'DAILY_MISSION_TASK_14'
 old = 'エピタフロードの大試練をクリアする'
+new = 'Complete one epitaph great ordeal'
 [[message]]
 key = 'DAILY_MISSION_TASK_13'
 old = '黒呪の迷宮１層をクリアする'
+new = 'Traverse one layer of Bitterblack Maze'
 [[message]]
 key = 'DAILY_MISSION_TASK_34'
 old = '黒呪の迷宮２層をクリアする'
+new = 'Traverse two layers of Bitterblack Maze'
 [[message]]
 key = 'DAILY_MISSION_TASK_35'
 old = '黒呪の迷宮３層をクリアする'
+new = 'Traverse three layers of Bitterblack Maze'
 [[message]]
 key = 'DAILY_MISSION_TASK_36'
 old = '黒呪の迷宮 深淵１層をクリアする'
+new = 'Traverse one layer of Bitterblack Maze Abyss'
 [[message]]
 key = 'DAILY_MISSION_TASK_37'
 old = '黒呪の迷宮 深淵２層をクリアする'
+new = 'Traverse two layers of Bitterblack Maze Abyss'
 [[message]]
 key = 'DAILY_MISSION_TASK_38'
 old = '黒呪の迷宮 深淵３層をクリアする'
+new = 'Traverse three layers of Bitterblack Maze Abyss'
 [[message]]
 key = 'DAILY_MISSION_TASK_39'
 old = '黒呪の迷宮 深淵４層をクリアする'
+new = 'Traverse four layers of Bitterblack Maze Abyss'

--- a/ui/00_message/dragon_skill/skill_info.toml
+++ b/ui/00_message/dragon_skill/skill_info.toml
@@ -6,8 +6,7 @@ old = '''
 new = '''
 During battle, Physical Attack/Magick Attack/
 Physical Defense/Magick Defense are increased.
-<COL ffdc78>LV UP Further increases the effectiveness.</COL>
-'''
+<COL ffdc78>LV UP Further increases the effectiveness.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_2'
 old = '''

--- a/ui/00_message/dragon_skill/skill_info.toml
+++ b/ui/00_message/dragon_skill/skill_info.toml
@@ -3,36 +3,62 @@ key = 'DRAGON_SKILL_INFO_1'
 old = '''
 戦闘中、物理攻撃力／魔法攻撃力／物理防御力／魔法防御力が増加する
 <COL ffdc78>LV UP毎にステータスアップ効果がより上昇</COL>'''
+new = '''
+During battle, Physical Attack/Magick Attack/
+Physical Defense/Magick Defense are increased.
+<COL ffdc78>LV UP Further increases the effectiveness.</COL>
+'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_2'
 old = '''
 アバドーンの弱点部位に一定量のダメージを与えると
 大ダメージを与える追撃が発生する
 <COL ffdc78>LV UP毎に追撃のダメージがより増加</COL>'''
+new = '''
+Deal a great amount damage to Abaddon after you inflict
+a certain amount of damage to its weak point.
+<COL ffdc78>LV UP Further increases bonus damage.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_3'
 old = '''
 バフォメットの弱点部位に一定量のダメージを与えると
 大ダメージを与える追撃が発生する
 <COL ffdc78>LV UP毎に追撃のダメージがより増加</COL>'''
+new = '''
+Deal a great amount damage to Baphomet after you inflict
+a certain amount of damage to its weak point.
+<COL ffdc78>LV UP Further increases bonus damage.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_4'
 old = '''
 黒騎士の弱点部位に一定量のダメージを与えると
 大ダメージを与える追撃が発生する
 <COL ffdc78>LV UP毎に追撃のダメージがより増加</COL>'''
+new = '''
+Deal a great amount damage to Black Knight after you inflict
+a certain amount of damage to its weak point.
+<COL ffdc78>LV UP Further increases bonus damage.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_5'
 old = '''
 黒竜の弱点部位、または黒竜により召喚された竜晶に
 一定量のダメージを与えると、大ダメージを与える追撃が発生する
 <COL ffdc78>LV UP毎に追撃のダメージがより増加</COL>'''
+new = '''
+Deal a great amount damage to Black Dragon and the summoned
+Dragon Crystal after you inflict a certain amount of damage
+to them.
+<COL ffdc78>LV UP Further increases bonus damage.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_6'
 old = '''
 大ダメージを受けるアバドーンの攻撃＜キラーアルベ＞の
 ダメージを軽減する。残り体力が少ない場合は発動しない
 <COL ffdc78>LV UP毎にダメージをさらに軽減</COL>'''
+new = '''
+Reduces damage of fatal attacks from Abaddon. Does not activate
+if your health is low.
+<COL ffdc78>LV UP Further reduces damage.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_7'
 old = '''
@@ -40,12 +66,22 @@ old = '''
 弱点部位を攻撃すると《精霊竜の反撃アイコン》が増加する
 アイコンが満了になると破壊可能部位へのダメージが大幅に増加する
 <COL ffdc78>LV UP毎にダメージがより増加</COL>'''
+new = '''
+When enemy strikes, attacking the part used by the attack
+will increase the "Spirit Dragon Counterattack Gauge".
+When the gauge is full, damage to destructible parts
+is greatly increased.
+<COL ffdc78>LV UP Further increases bonus damage.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_8'
 old = '''
 闇炎の状態異常にかかった際に回復までの時間を短縮する
 回復までの時間は、付与される毎にやや増減する
 <COL ffdc78>LV UP毎に回復までの時間がさらに短縮</COL>'''
+new = '''
+Shorten the recovery time of Dark Flame debilitation. The time
+needed slightly increases or decreases each time this is triggered.
+<COL ffdc78>LV UP Further shortens the recovery time.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_9'
 old = '''
@@ -54,6 +90,13 @@ old = '''
 バリア展開中は筋力／魔力／疲労攻力／チャンス攻力が増加するが
 魔法攻撃を受けるか時間経過によりバリアの耐久値は減少する
 <COL ffdc78>LV UP毎にステータスアップ効果／バリアの耐久値がより上昇</COL>'''
+new = '''
+Create a barrier to disable the "Magick Attack Increase" buff
+from enemy. While inside the barrier, Strength/Magick/
+Chance Attack/Exhaust Attack are increased. The durability of the
+barrier deteriotates over time and magick damage taken.
+<COL ffdc78>LV UP Further increases the stat bonus and duration
+of the barrier.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_10'
 old = '''
@@ -62,6 +105,13 @@ old = '''
 バリア展開中は筋力／魔力／疲労攻力／チャンス攻力が増加するが
 物理攻撃を受けるか時間経過によりバリアの耐久値は減少する
 <COL ffdc78>LV UP毎にステータスアップ効果／バリアの耐久値がより上昇</COL>'''
+new = '''
+Create a barrier to disable the "Physical Attack Increase" buff
+from enemy. While inside the barrier, Strength/Magick/
+Chance Attack/Exhaust Attack are increased. The durability of the
+barrier deteriotates over time and physical damage taken.
+<COL ffdc78>LV UP Further increases the stat bonus and duration
+of the barrier.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_11'
 old = '''
@@ -70,14 +120,28 @@ old = '''
 鎧硬化状態を解除すると、敵が体勢を崩している間
 筋力／魔力／疲労攻力／チャンス攻力が増加する追加効果が発動する
 <COL ffdc78>LV UP毎にステータスアップ効果がより上昇</COL>'''
+new = '''
+Blow power increases in response to "Armor Harden" state triggered
+by enemy, making it easier to break through their armor. When the
+enemy is in the staggered state, Strength/Magick/Exhaust Attack/
+Chance Attack increase.
+<COL ffdc78>LV UP Further increases the stat bonus.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_12'
 old = '''
 ボス撃破時に獲得できる宝箱報酬が増加する
 <COL ffdc78>LV UP毎に報酬がより増加</COL>'''
+new = '''
+Increases the reward from chests after killing the boss.
+<COL ffdc78>LV UP Further increases the reward.</COL>'''
 [[message]]
 key = 'DRAGON_SKILL_INFO_13'
 old = '''
 黄金竜の攻撃により、敵の特定の攻撃を中断する
 攻撃を中断すると＜破滅の力＞の蓄積量が減少する
 <COL ffdc78>LV UP毎に破滅の力の減少量がより増加</COL>'''
+new = '''
+The Golden Dragon attacks, trying to interrupt a specific
+attack of the enemy. If the interruption succeeds, the
+"Power of Destruction" is lowered.
+<COL ffdc78>LV UP Further decreases the Destruction power.</COL>'''

--- a/ui/00_message/dragon_skill/skill_name.toml
+++ b/ui/00_message/dragon_skill/skill_name.toml
@@ -13,7 +13,7 @@ new = 'Demon Slayer'
 [[message]]
 key = 'DRAGON_SKILL_NAME_4'
 old = 'ゴーストスレイヤー'
-new = 'Ghost Slayer'
+new = 'Spirit Slayer'
 [[message]]
 key = 'DRAGON_SKILL_NAME_5'
 old = 'ドラゴンスレイヤー'

--- a/ui/00_message/npc/func_class_name.toml
+++ b/ui/00_message/npc/func_class_name.toml
@@ -202,6 +202,7 @@ new = 'Pawn Expedition Corps'
 [[message]]
 key = 'FUNC_CLASS_NAME_56'
 old = '遠征成果の確認'
+new = 'Check Expedition Result'
 [[message]]
 key = 'FUNC_CLASS_NAME_57'
 old = 'プレイポイントショップ'
@@ -376,6 +377,7 @@ new = 'Dragon Ability Synthesis'
 [[message]]
 key = 'FUNC_CLASS_NAME_102'
 old = '竜防具の鑑定交換'
+new = 'Dragon Armor Appraisal'
 [[message]]
 key = 'FUNC_CLASS_NAME_103'
 old = 'リワードミッション'

--- a/ui/00_message/skill/ability_info.toml
+++ b/ui/00_message/skill/ability_info.toml
@@ -3329,7 +3329,7 @@ old = '''
 全てのノーマルスキルのダメージ量が増加する
 <COL ffdc78>LV UP毎にダメージがより増加</COL>'''
 new = '''
-Increases damage of all normal skills.
+Increases damage of all core skills.
 <COL ffdc78>LV UP: Further increases damage.</COL>'''
 [[message]]
 key = 'ABILITY_INFO_256'

--- a/ui/00_message/skill/ability_name.toml
+++ b/ui/00_message/skill/ability_name.toml
@@ -457,7 +457,7 @@ new = 'Construct Proficiency'
 [[message]]
 key = 'ABILITY_NAME_200'
 old = '獣狙'
-new = 'Poacher'
+new = 'Beast Proficiency'
 [[message]]
 key = 'ABILITY_NAME_222'
 old = '錬護'

--- a/ui/00_message/skill/custom_skill_name_10.toml
+++ b/ui/00_message/skill/custom_skill_name_10.toml
@@ -21,7 +21,7 @@ new = 'Corr Storm'
 [[message]]
 key = 'CUSTOM_SKILL_NAME_10_147'
 old = 'シュクリス・ブラスト'
-new = 'Shukris Blast'
+new = 'Scrios Blast'
 [[message]]
 key = 'CUSTOM_SKILL_NAME_10_150'
 old = 'キュア・グラスタ'

--- a/ui/00_message/ui/common_message.toml
+++ b/ui/00_message/ui/common_message.toml
@@ -683,7 +683,7 @@ old = '冒険回数0'
 [[message]]
 key = 'common_msg_jp_of'
 old = 'の'
-new = '’s '
+new = "'s "
 [[message]]
 key = 'common_msg_attribute_A1'
 old = '斬'

--- a/ui/00_message/ui/common_message.toml
+++ b/ui/00_message/ui/common_message.toml
@@ -683,7 +683,7 @@ old = '冒険回数0'
 [[message]]
 key = 'common_msg_jp_of'
 old = 'の'
-new = '’'
+new = '’s '
 [[message]]
 key = 'common_msg_attribute_A1'
 old = '斬'
@@ -727,7 +727,7 @@ new = ' Attribute'
 [[message]]
 key = 'common_msg_jp_damage'
 old = 'ダメージ'
-new = 'Damage'
+new = ' Damage'
 [[message]]
 key = 'common_msg_en_parameter'
 old = 'Parameter'

--- a/ui/00_message/ui/common_message.toml
+++ b/ui/00_message/ui/common_message.toml
@@ -683,37 +683,47 @@ old = '冒険回数0'
 [[message]]
 key = 'common_msg_jp_of'
 old = 'の'
+new = '’'
 [[message]]
 key = 'common_msg_attribute_A1'
 old = '斬'
+new = 'Slash'
 [[message]]
 key = 'common_msg_attribute_A2'
 old = '打'
+new = 'Impact'
 [[message]]
 key = 'common_msg_attribute_A3'
 old = '射'
+new = 'Pierce'
 [[message]]
 key = 'common_msg_attribute_B1'
 old = '無'
+new = 'Null'
 [[message]]
 key = 'common_msg_attribute_B2'
 old = '炎'
+new = 'Fire'
 [[message]]
 key = 'common_msg_attribute_B3'
 old = '氷'
+new = 'Ice'
 [[message]]
 key = 'common_msg_attribute_B4'
 old = '雷'
+new = 'Thunder'
 [[message]]
 key = 'common_msg_attribute_B5'
 old = '聖'
+new = 'Holy'
 [[message]]
 key = 'common_msg_attribute_B6'
 old = '闇'
+new = 'Dark'
 [[message]]
 key = 'common_msg_jp_attribute'
 old = '属性'
-new = 'Attribute'
+new = ' Attribute'
 [[message]]
 key = 'common_msg_jp_damage'
 old = 'ダメージ'
@@ -745,9 +755,12 @@ old = '指定'
 [[message]]
 key = 'common_enemy_transform_division_01'
 old = '・分身体'
+new = ' (Avatar)'
 [[message]]
 key = 'common_enemy_transform_division_02'
 old = '・分身体Ⅰ'
+new = ' (Avatar 1)'
 [[message]]
 key = 'common_enemy_transform_division_03'
 old = '・分身体Ⅱ'
+new = ' (Avatar 2)'

--- a/ui/00_message/ui/entry_board.toml
+++ b/ui/00_message/ui/entry_board.toml
@@ -498,11 +498,11 @@ new = 'Bonus Dragon Ability'
 [[message]]
 key = 'entry_board_dra_skill_msg_004'
 old = 'パーティー合計='
-new = 'Party total ='
+new = 'Party total = '
 [[message]]
 key = 'entry_board_dra_skill_msg_005'
 old = '個人合計='
-new = 'Personal total ='
+new = 'Personal total = '
 [[message]]
 key = 'entry_board_dra_skill_msg_006'
 old = '発動中'

--- a/ui/00_message/ui/entry_board.toml
+++ b/ui/00_message/ui/entry_board.toml
@@ -518,15 +518,15 @@ new = 'Inactive'
 [[message]]
 key = 'entry_board_dra_skill_msg_009'
 old = '有利：'
-new = 'Advantagous: '
+new = 'ADV: '
 [[message]]
 key = 'entry_board_dra_skill_msg_010'
 old = '適正：'
-new = 'Reasonable: '
+new = 'OK: '
 [[message]]
 key = 'entry_board_dra_skill_msg_011'
 old = '不利：'
-new = 'Disadvantagous: '
+new = 'DIS: '
 [[message]]
 key = 'entry_board_dra_skill_msg_012'
 old = '募集：'
@@ -534,4 +534,4 @@ new = 'Recruit: '
 [[message]]
 key = 'entry_board_dra_skill_msg_013'
 old = 'ボーナス発動'
-new = 'Bonus activation'
+new = 'Bonus Buff'

--- a/ui/00_message/ui/entry_board.toml
+++ b/ui/00_message/ui/entry_board.toml
@@ -474,48 +474,64 @@ new = 'D Rank: <VAL DP>'
 [[message]]
 key = 'entry_board_recommend_counter_skill_title'
 old = '推奨ドラゴンアビリティ'
+new = 'Recommended Dragon Ability'
 [[message]]
 key = 'entry_board_playable_time_header'
 old = '出撃可能時間'
+new = 'Sortie Time'
 [[message]]
 key = 'entry_board_playable_time_info'
 old = '<DATE> - <DATE>'
+new = '<DATE> - <DATE>'
 [[message]]
 key = 'entry_board_dra_skill_msg_001'
 old = 'ドラゴンアビリティ指定'
+new = 'Dragon Ability Designation'
 [[message]]
 key = 'entry_board_dra_skill_msg_002'
 old = 'ドラゴンアビリティ情報'
+new = 'Dragon Ability Information'
 [[message]]
 key = 'entry_board_dra_skill_msg_003'
 old = 'ボーナスドラゴンアビリティ'
+new = 'Bonus Dragon Ability'
 [[message]]
 key = 'entry_board_dra_skill_msg_004'
 old = 'パーティー合計='
+new = 'Party total ='
 [[message]]
 key = 'entry_board_dra_skill_msg_005'
 old = '個人合計='
+new = 'Personal total ='
 [[message]]
 key = 'entry_board_dra_skill_msg_006'
 old = '発動中'
+new = 'Active'
 [[message]]
 key = 'entry_board_dra_skill_msg_007'
 old = '―'
+new = '-'
 [[message]]
 key = 'entry_board_dra_skill_msg_008'
 old = '未発動'
+new = 'Inactive'
 [[message]]
 key = 'entry_board_dra_skill_msg_009'
 old = '有利：'
+new = 'Advantagous: '
 [[message]]
 key = 'entry_board_dra_skill_msg_010'
 old = '適正：'
+new = 'Reasonable: '
 [[message]]
 key = 'entry_board_dra_skill_msg_011'
 old = '不利：'
+new = 'Disadvantagous: '
 [[message]]
 key = 'entry_board_dra_skill_msg_012'
 old = '募集：'
+new = 'Recruit: '
 [[message]]
 key = 'entry_board_dra_skill_msg_013'
 old = 'ボーナス発動'
+new = 'Bonus activation'

--- a/ui/00_message/ui/hud.toml
+++ b/ui/00_message/ui/hud.toml
@@ -348,6 +348,7 @@ new = 'Need %s magick stack!'
 [[message]]
 key = 'hud_name_om_safetydome'
 old = '護身の結界'
+new = 'Barrier of Defense'
 [[message]]
 key = 'hud_get_announce_gdm_ex'
 old = '<VAL> <VAL> $#'
@@ -363,21 +364,28 @@ old = 'Chain'
 [[message]]
 key = 'hud_dragon_skill_pl_1'
 old = '“%s”を発動した！'
+new = '"%s" has activated!'
 [[message]]
 key = 'hud_dragon_skill_pl_2'
 old = '渾身の“%s”を発動した！'
+new = '"%s" has fully activated!'
 [[message]]
 key = 'hud_dragon_skill_pl_0'
 old = '“%s”を発動できなかった――'
+new = '"%s" could not be activated'
 [[message]]
 key = 'hud_dark_dungeon_p_0'
 old = 'ダンジョン内の異変を調査せよ'
+new = 'Investigate the abnomalities in the dungeon'
 [[message]]
 key = 'hud_job_elementarcher_single'
 old = 'シングルロックオン'
+new = 'Single Lock On'
 [[message]]
 key = 'hud_job_elementarcher_multi'
 old = 'マルチロックオン'
+new = 'Multi Lock On'
 [[message]]
 key = 'hud_announce_dragon_skill_set'
 old = 'ドラゴンアビリティが発動した！'
+new = 'Dragon ability has activated!'

--- a/ui/00_message/ui/pick_res.toml
+++ b/ui/00_message/ui/pick_res.toml
@@ -41,6 +41,9 @@ key = 'pick_item_err_001'
 old = '''
 このアイテムは個別に受け取ることができません
 【すべて受け取る】を押してください'''
+new = '''
+Cannot receive items individually
+Please select "Take All"'''
 [[message]]
 key = 'pick_item_btn_000'
 old = '受け取る'
@@ -54,3 +57,7 @@ key = 'pick_item_err_002'
 old = '''
 必要アイテム（<NAME ITEM>×<VAL>）を
 アイテムバッグに所持していないため、受け取れません'''
+new = '''
+You cannot receive items because
+you do not carry enough items in the bag
+(<NAME ITEM>×<VAL>)'''

--- a/ui/00_message/ui/system_log.toml
+++ b/ui/00_message/ui/system_log.toml
@@ -1558,53 +1558,72 @@ old = '<UNTN RDM>を<VAL>(+<VAL>)<UNIT RDM>、入手しました'
 [[message]]
 key = 'syslog_ds_info_enemy_01'
 old = '敵が闇の炎をまとった！'
+new = 'The enemy is shrouded in dark flame!'
 [[message]]
 key = 'syslog_ds_info_enemy_02'
 old = '敵の魔法攻撃力が上昇した！'
+new = 'Magick attack of the enemy has increased!'
 [[message]]
 key = 'syslog_ds_info_enemy_03'
 old = '敵の物理攻撃力が上昇した！'
+new = 'Physical attack of the enemy has increased!'
 [[message]]
 key = 'syslog_ds_info_enemy_04'
 old = '敵の鎧が硬化した！'
+new = 'The armor of enemy has hardened!'
 [[message]]
 key = 'syslog_ds_support_ana_01'
 old = '竜の祝福により報酬が強化された'
+new = 'Blessing of the Dragons have improved the reward.'
 [[message]]
 key = 'syslog_ds_support_ana_02'
 old = '敵の部位を破壊しやすくなった'
+new = 'It is now easier to break destructible parts.'
 [[message]]
 key = 'syslog_ds_support_ana_03'
 old = '敵の防御を破り、プレイヤーの攻撃力が強化された'
+new = 'Break through their defense to enhance your offensive power.'
 [[message]]
 key = 'syslog_pp_possession_max'
 old = 'プレイポイントが最大に達したため、これ以上獲得できません'
+new = 'You have reached the maximum amount of PP and cannot earn any more.'
 [[message]]
 key = 'syslog_g_possession_max'
 old = '<UNTN G>が最大に達したため、これ以上獲得できません'
+new = 'You have reached the maximum amount of <UNTN G> and cannot earn any more.'
 [[message]]
 key = 'syslog_r_possession_max'
 old = '<UNTN R>が最大に達したため、これ以上獲得できません'
+new = 'You have reached the maximum amount of <UNTN R> and cannot earn any more.'
 [[message]]
 key = 'syslog_bo_possession_max'
 old = '<UNTN BO>が最大に達したため、これ以上獲得できません'
+new = 'You have reached the maximum amount of <UNTN BO> and cannot earn any more.'
 [[message]]
 key = 'syslog_ho_possession_max'
 old = '<UNTN HB>が最大に達したため、これ以上獲得できません'
+new = 'You have reached the maximum amount of <UNTN HB> and cannot earn any more.'
 [[message]]
 key = 'syslog_rp_possession_max'
 old = '<UNTN RP>が最大に達したため、これ以上獲得できません'
+new = 'You have reached the maximum amount of <UNTN RP> and cannot earn any more.'
 [[message]]
 key = 'syslog_ms_possession_max'
 old = '<UNTN MS>が最大に達したため、これ以上獲得できません'
+new = 'You have reached the maximum amount of <UNTN MS> and cannot earn any more.'
 [[message]]
 key = 'syslog_darkgauge_rise'
 old = '''
 “破滅の力”の高まりを感じる――
 ゲージが十分に溜まるとすべてが滅びる！'''
+new = '''
+The Power of Destruction is growing...
+When it reaches maximum power, all life will perish!'''
 [[message]]
 key = 'syslog_darkgauge_growup'
 old = '“破滅の力”のゲージが徐々に上昇してゆく！'
+new = 'The Power of Destruction is rising!'
 [[message]]
 key = 'syslog_darkgauge_spdown'
 old = '“黄金竜の一撃”によって“破滅の力”のゲージが減少した！'
+new= 'The attack of Golden Dragon has reduced the Power of Destruction!'


### PR DESCRIPTION
- Attempt to translate the new BBM's effects. Not sure if the layout is good though. As of now, the effect’s description is pretty cramped already. Currently it goes “Shield Sageの闇AttributeDamage+10%”. With this update, it will become “Shield Sage’s Dark Attribute Damage+10%”. I can omit the word “Attribute” if you want.
- Translate some new system message.
- Translate the Dragon skills description and change the name 'Ghost Slayer' to 'Spirit Slayer' to match with the proficiency augment (Spirit Proficiency) and slayer (Spirit Slayer).
- Change 'Poacher' augment to 'Beast Proficiency' to match with other similar augments.